### PR TITLE
refactor(devenv): switch to nixpkgs-unstable.

### DIFF
--- a/devenv.lock
+++ b/devenv.lock
@@ -3,11 +3,11 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1725287955,
+        "lastModified": 1725464985,
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "0ceddcb8040b72943d34af364cde79294222e1af",
-        "treeHash": "3950480113111b9ffacc5b7a2fb08d27e40ac0cd",
+        "rev": "325588271687d275632958b4c988ef7a05772f65",
+        "treeHash": "a85a79c0941bff354a040b6d17fe1f542a661ed1",
         "type": "github"
       },
       "original": {
@@ -126,17 +126,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1716977621,
-        "owner": "cachix",
-        "repo": "devenv-nixpkgs",
-        "rev": "4267e705586473d3e5c8d50299e71503f16a6fb6",
-        "treeHash": "6d9f1f7ca0faf1bc2eeb397c78a49623260d3412",
+        "lastModified": 1725194671,
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b833ff01a0d694b910daca6e2ff4a3f26dee478c",
+        "treeHash": "bb5efa178da5cad3d41f9557a800b8fa3033c1f5",
         "type": "github"
       },
       "original": {
-        "owner": "cachix",
-        "ref": "rolling",
-        "repo": "devenv-nixpkgs",
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
         "type": "github"
       }
     },
@@ -163,11 +163,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1725001927,
+        "lastModified": 1725407940,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6e99f2a27d600612004fbd2c3282d614bfee6421",
-        "treeHash": "1e85443cc9f0ba302df2cf61cacb8014943e2d19",
+        "rev": "6f6c45b5134a8ee2e465164811e451dcb5ad86e3",
+        "treeHash": "f65d5344b23cfbe3695140b602bc463349b26638",
         "type": "github"
       },
       "original": {
@@ -187,11 +187,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1724857454,
+        "lastModified": 1725513492,
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "4509ca64f1084e73bc7a721b20c669a8d4c5ebe6",
-        "treeHash": "ced5a8df7c554ce10bf26223c002f41b31aff034",
+        "rev": "7570de7b9b504cfe92025dd1be797bf546f66528",
+        "treeHash": "4b46d77870afecd8f642541cb4f4927326343b59",
         "type": "github"
       },
       "original": {

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,17 +1,9 @@
-{
-  pkgs,
-  lib,
-  config,
-  inputs,
-  ...
-}:
+{ pkgs, lib, config, inputs, ... }:
 
 {
   name = "sparkle";
   # https://devenv.sh/basics/
-  env = {
-    GREET = "🛠️ Let's hack ";
-  };
+  env = { GREET = "🛠️ Let's hack "; };
 
   # https://devenv.sh/scripts/
   scripts.hello.exec = "echo $GREET";
@@ -34,12 +26,7 @@
   };
 
   # https://devenv.sh/packages/
-  packages = with pkgs; [
-    nixfmt-rfc-style
-    bat
-    jq
-    tealdeer
-  ];
+  packages = with pkgs; [ nixfmt-rfc-style bat jq tealdeer ];
 
   languages = {
 
@@ -61,7 +48,7 @@
   };
 
   languages.java.enable = true;
-  languages.java.jdk.package = pkgs.jdk17;
+  languages.java.jdk.package = pkgs.jdk8; # Java version running on AWS Glue
 
   enterShell = ''
     hello

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -7,7 +7,7 @@ inputs:
   mk-shell-bin:
     url: github:rrbutani/nix-mk-shell-bin
   nixpkgs:
-    url: github:cachix/devenv-nixpkgs/rolling
+    url: github:NixOS/nixpkgs/nixpkgs-unstable
   nixpkgs-python:
     url: github:cachix/nixpkgs-python
     inputs:


### PR DESCRIPTION
`devenv` has switched to its own mirror of nixpkgs, called rolling
[available here](https://github.com/cachix/devenv-nixpkgs) which
currently causes any non nix installation of a package like Spark to
fail with the following error (only on Linux runtime):

```
Java gateway process exited before sending its port number
```

This commit, switches back to `nixpkgs-unstable` which works globally.