### PR TITLE
fix: python version locking

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 dependencies = [
     "pyspark==3.3.2"
 ]
-requires-python = "==3.10.14"
+requires-python = ">=3.10.14"
 readme = "README.md"
 license = {text = "Apache-2.0"}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     {name = "Reza (Shahin) Khanipour", email = "shahin@DataChef.co"},
 ]
 dependencies = [
-    "pyspark==3.3.2"
+    "pyspark>=3.3.2"
 ]
 requires-python = ">=3.10.14"
 readme = "README.md"


### PR DESCRIPTION
# Description

Currently, Sparkle locked requireed-python version to exact 3.10.14 which causes issues when in a project the python version is higher. This PR suggest a minimum version for both pyspark and python instead of locking to specific version.