### PR TITLE
fix: package version in the package.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ types-confluent-kafka = "^1.2.2"
 version = "1.0.0"
 update_changelog_on_bump = true
 version_provider = "scm"
-tag_format = "v$major.$minor.$patch$prerelease"
+tag_format = "v$version"
 version_files = [
     "pyproject.toml:version",
     "src/sparkle/__init__.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ update_changelog_on_bump = true
 version_provider = "scm"
 tag_format = "v$major.$minor.$patch$prerelease"
 version_files = [
+    "pyproject.toml:version",
     "src/sparkle/__init__.py"
 ]
 


### PR DESCRIPTION
Commitizen wasn't updating the pyproject.toml version. Thus after installation, it was always locked with version 0.0.0 in the client project. 